### PR TITLE
Update GitHub URLs to point to new repo location

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,7 @@ Getting ready:
 - [ ] Recommended VSCode extensions installed (especially the formatter. It should automatically format on every save!)
 - [ ] on branch `value-wizard` with latest commit pulled
 - [ ] Work through the `Setup` section below (especially to install the necessary dependencies)
-- [ ] Read the [`README.md`](https://github.com/paul019/ResultWizard/tree/value-wizard/src#code-structure) in the `src` folder (to get to know the code structure) & see our [feature list](https://github.com/paul019/ResultWizard/issues/16)
+- [ ] Read the [`README.md`](https://github.com/resultwizard/ResultWizard/tree/main/src#code-structure) in the `src` folder (to get to know the code structure) & see our [feature list](https://github.com/resultwizard/ResultWizard/issues/16)
 
 Verify that everything worked:
 - [ ] try to run the tests, see the instructions in [`tests/playground.py`](./tests/playground.py)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://github.com/paul019/ResultWizard/assets/37160523/8576038a-3867-470b-8f42-90b60ea92042" width="120px" />
+  <img src="https://github.com/resultwizard/ResultWizard/assets/37160523/8576038a-3867-470b-8f42-90b60ea92042" width="120px" />
   <div align="center">
     <h3 align="center">ResultWizard</h3>
     <p><strong>Intelligent interface between Python-computed values and your LaTeX work</strong></p>

--- a/TODO.md
+++ b/TODO.md
@@ -19,5 +19,5 @@
 ## Other
 
 - Setup issue template and contribution guide. Clean up `DEVELOPMENT.md`.
-- Long-term: Ask real users what they really need in the scientific day-to-day life, see [here](https://github.com/paul019/ResultWizard/issues/9).
+- Long-term: Ask real users what they really need in the scientific day-to-day life, see [here](https://github.com/resultwizard/ResultWizard/issues/9).
 - If user enters an uncertainty of `0.0`, don't just issue warning "Uncertainty must be positive", but also give a hint that the user might want to use a different caller syntax for `res` which does not even have the uncertainty as argument.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/paul019/ResultWizard"
-Repository = "https://github.com/paul019/ResultWizard"
-Issues = "https://github.com/paul019/ResultWizard/issues"
-Changelog = "https://github.com/paul019/ResultWizard/blob/main/CHANGELOG.md"
+Homepage = "https://resultwizard.github.io/ResultWizard/"
+Repository = "https://github.com/resultwizard/ResultWizard"
+Issues = "https://github.com/resultwizard/ResultWizard/issues"
+Changelog = "https://github.com/resultwizard/ResultWizard/blob/main/CHANGELOG.md"
 
 # TODO: Add these checks back
 [tool.pylint."messages control"]


### PR DESCRIPTION
Note that the docs link will only work once our documentation is merged to main, see #37.